### PR TITLE
Remove xmlns=""

### DIFF
--- a/xsds/Calcium/1.2/MethodModifications.xsd
+++ b/xsds/Calcium/1.2/MethodModifications.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:simpleType name="Version">
     <xs:restriction base="xs:string">

--- a/xsds/Calcium/2.0/MethodModifications.xsd
+++ b/xsds/Calcium/2.0/MethodModifications.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:simpleType name="Version">
     <xs:restriction base="xs:string">

--- a/xsds/Calcium/2.1/MethodModifications.xsd
+++ b/xsds/Calcium/2.1/MethodModifications.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:simpleType name="Version">
     <xs:restriction base="xs:string">

--- a/xsds/Calcium/3.0/MethodModifications.xsd
+++ b/xsds/Calcium/3.0/MethodModifications.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:simpleType name="Version">
     <xs:restriction base="xs:string">

--- a/xsds/Calcium/3.1/MethodModifications.xsd
+++ b/xsds/Calcium/3.1/MethodModifications.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:simpleType name="Version">
     <xs:restriction base="xs:string">

--- a/xsds/Hyperion/1.2/Common.xsd
+++ b/xsds/Hyperion/1.2/Common.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:attribute name="InUse" type="xs:boolean" />
 

--- a/xsds/Hyperion/1.2/GlobalParams.xsd
+++ b/xsds/Hyperion/1.2/GlobalParams.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="Common.xsd"/>
 

--- a/xsds/Hyperion/1.2/HyperionMassListParams.xsd
+++ b/xsds/Hyperion/1.2/HyperionMassListParams.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="Common.xsd"/>
 

--- a/xsds/Hyperion/1.2/HyperionMethod.xsd
+++ b/xsds/Hyperion/1.2/HyperionMethod.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
 	<xs:include schemaLocation="GlobalParams.xsd"/>
 	<xs:include schemaLocation="Hyperion_SRMExp.xsd"/>

--- a/xsds/Hyperion/1.2/HyperionMethodParams.xsd
+++ b/xsds/Hyperion/1.2/HyperionMethodParams.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="Common.xsd" />
   

--- a/xsds/Hyperion/1.2/Hyperion_COExp.xsd
+++ b/xsds/Hyperion/1.2/Hyperion_COExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
 	<xs:include schemaLocation="HyperionMethodParams.xsd" />
 	<xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/1.2/Hyperion_FullScanExp.xsd
+++ b/xsds/Hyperion/1.2/Hyperion_FullScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/1.2/Hyperion_MixedScanExp.xsd
+++ b/xsds/Hyperion/1.2/Hyperion_MixedScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
 	<xs:include schemaLocation="Hyperion_SRMExp.xsd" />
 	<xs:include schemaLocation="Hyperion_SIMExp.xsd" />

--- a/xsds/Hyperion/1.2/Hyperion_NLScanExp.xsd
+++ b/xsds/Hyperion/1.2/Hyperion_NLScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/1.2/Hyperion_PrecursorScanExp.xsd
+++ b/xsds/Hyperion/1.2/Hyperion_PrecursorScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/1.2/Hyperion_ProductScanExp.xsd
+++ b/xsds/Hyperion/1.2/Hyperion_ProductScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/1.2/Hyperion_QEDExp.xsd
+++ b/xsds/Hyperion/1.2/Hyperion_QEDExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/1.2/Hyperion_SIMExp.xsd
+++ b/xsds/Hyperion/1.2/Hyperion_SIMExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/1.2/Hyperion_SRMExp.xsd
+++ b/xsds/Hyperion/1.2/Hyperion_SRMExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.0/Common.xsd
+++ b/xsds/Hyperion/2.0/Common.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:attribute name="InUse" type="xs:boolean" />
 

--- a/xsds/Hyperion/2.0/GlobalParams.xsd
+++ b/xsds/Hyperion/2.0/GlobalParams.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="Common.xsd"/>
 

--- a/xsds/Hyperion/2.0/HyperionMassListParams.xsd
+++ b/xsds/Hyperion/2.0/HyperionMassListParams.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="Common.xsd"/>
 

--- a/xsds/Hyperion/2.0/HyperionMethod.xsd
+++ b/xsds/Hyperion/2.0/HyperionMethod.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
 	<xs:include schemaLocation="GlobalParams.xsd"/>
 	<xs:include schemaLocation="Hyperion_SRMExp.xsd"/>

--- a/xsds/Hyperion/2.0/HyperionMethodParams.xsd
+++ b/xsds/Hyperion/2.0/HyperionMethodParams.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="Common.xsd" />
   

--- a/xsds/Hyperion/2.0/Hyperion_COExp.xsd
+++ b/xsds/Hyperion/2.0/Hyperion_COExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
 	<xs:include schemaLocation="HyperionMethodParams.xsd" />
 	<xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.0/Hyperion_FullScanExp.xsd
+++ b/xsds/Hyperion/2.0/Hyperion_FullScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.0/Hyperion_MixedScanExp.xsd
+++ b/xsds/Hyperion/2.0/Hyperion_MixedScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
 	<xs:include schemaLocation="Hyperion_SRMExp.xsd" />
 	<xs:include schemaLocation="Hyperion_SIMExp.xsd" />

--- a/xsds/Hyperion/2.0/Hyperion_NLScanExp.xsd
+++ b/xsds/Hyperion/2.0/Hyperion_NLScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.0/Hyperion_PrecursorScanExp.xsd
+++ b/xsds/Hyperion/2.0/Hyperion_PrecursorScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.0/Hyperion_ProductScanExp.xsd
+++ b/xsds/Hyperion/2.0/Hyperion_ProductScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.0/Hyperion_QEDExp.xsd
+++ b/xsds/Hyperion/2.0/Hyperion_QEDExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.0/Hyperion_SIMExp.xsd
+++ b/xsds/Hyperion/2.0/Hyperion_SIMExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.0/Hyperion_SRMExp.xsd
+++ b/xsds/Hyperion/2.0/Hyperion_SRMExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.1/Common.xsd
+++ b/xsds/Hyperion/2.1/Common.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:attribute name="InUse" type="xs:boolean" />
 

--- a/xsds/Hyperion/2.1/GlobalParams.xsd
+++ b/xsds/Hyperion/2.1/GlobalParams.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="Common.xsd"/>
 

--- a/xsds/Hyperion/2.1/HyperionMassListParams.xsd
+++ b/xsds/Hyperion/2.1/HyperionMassListParams.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="Common.xsd"/>
 

--- a/xsds/Hyperion/2.1/HyperionMethod.xsd
+++ b/xsds/Hyperion/2.1/HyperionMethod.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
 	<xs:include schemaLocation="GlobalParams.xsd"/>
 	<xs:include schemaLocation="Hyperion_SRMExp.xsd"/>

--- a/xsds/Hyperion/2.1/HyperionMethodParams.xsd
+++ b/xsds/Hyperion/2.1/HyperionMethodParams.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="Common.xsd" />
   

--- a/xsds/Hyperion/2.1/Hyperion_COExp.xsd
+++ b/xsds/Hyperion/2.1/Hyperion_COExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
 	<xs:include schemaLocation="HyperionMethodParams.xsd" />
 	<xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.1/Hyperion_FullScanExp.xsd
+++ b/xsds/Hyperion/2.1/Hyperion_FullScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.1/Hyperion_MixedScanExp.xsd
+++ b/xsds/Hyperion/2.1/Hyperion_MixedScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
 	<xs:include schemaLocation="Hyperion_SRMExp.xsd" />
 	<xs:include schemaLocation="Hyperion_SIMExp.xsd" />

--- a/xsds/Hyperion/2.1/Hyperion_NLScanExp.xsd
+++ b/xsds/Hyperion/2.1/Hyperion_NLScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.1/Hyperion_PrecursorScanExp.xsd
+++ b/xsds/Hyperion/2.1/Hyperion_PrecursorScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.1/Hyperion_ProductScanExp.xsd
+++ b/xsds/Hyperion/2.1/Hyperion_ProductScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.1/Hyperion_QEDExp.xsd
+++ b/xsds/Hyperion/2.1/Hyperion_QEDExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.1/Hyperion_SIMExp.xsd
+++ b/xsds/Hyperion/2.1/Hyperion_SIMExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/2.1/Hyperion_SRMExp.xsd
+++ b/xsds/Hyperion/2.1/Hyperion_SRMExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/3.0/Common.xsd
+++ b/xsds/Hyperion/3.0/Common.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:attribute name="InUse" type="xs:boolean" />
 

--- a/xsds/Hyperion/3.0/GlobalParams.xsd
+++ b/xsds/Hyperion/3.0/GlobalParams.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="Common.xsd"/>
 

--- a/xsds/Hyperion/3.0/HyperionMassListParams.xsd
+++ b/xsds/Hyperion/3.0/HyperionMassListParams.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="Common.xsd"/>
 

--- a/xsds/Hyperion/3.0/HyperionMethod.xsd
+++ b/xsds/Hyperion/3.0/HyperionMethod.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
 	<xs:include schemaLocation="GlobalParams.xsd"/>
 	<xs:include schemaLocation="Hyperion_SRMExp.xsd"/>

--- a/xsds/Hyperion/3.0/HyperionMethodParams.xsd
+++ b/xsds/Hyperion/3.0/HyperionMethodParams.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="Common.xsd" /> 
 

--- a/xsds/Hyperion/3.0/Hyperion_COExp.xsd
+++ b/xsds/Hyperion/3.0/Hyperion_COExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
 	<xs:include schemaLocation="HyperionMethodParams.xsd" />
 	<xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/3.0/Hyperion_FullScanExp.xsd
+++ b/xsds/Hyperion/3.0/Hyperion_FullScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/3.0/Hyperion_MixedScanExp.xsd
+++ b/xsds/Hyperion/3.0/Hyperion_MixedScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
 	<xs:include schemaLocation="Hyperion_SRMExp.xsd" />
 	<xs:include schemaLocation="Hyperion_SIMExp.xsd" />

--- a/xsds/Hyperion/3.0/Hyperion_NLScanExp.xsd
+++ b/xsds/Hyperion/3.0/Hyperion_NLScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/3.0/Hyperion_PrecursorScanExp.xsd
+++ b/xsds/Hyperion/3.0/Hyperion_PrecursorScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/3.0/Hyperion_ProductScanExp.xsd
+++ b/xsds/Hyperion/3.0/Hyperion_ProductScanExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/3.0/Hyperion_QEDExp.xsd
+++ b/xsds/Hyperion/3.0/Hyperion_QEDExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/3.0/Hyperion_SIMExp.xsd
+++ b/xsds/Hyperion/3.0/Hyperion_SIMExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />

--- a/xsds/Hyperion/3.0/Hyperion_SRMExp.xsd
+++ b/xsds/Hyperion/3.0/Hyperion_SRMExp.xsd
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<xs:schema xmlns="" xmlns:xs="http://www.w3.org/2001/XMLSchema" >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" >
 
   <xs:include schemaLocation="HyperionMethodParams.xsd" />
   <xs:include schemaLocation="HyperionMassListParams.xsd" />


### PR DESCRIPTION
Dear Thermo developers,

all xsd files contain an empty URI for the xml namespace (`xmlns=""`). I am not an XML expert but according to https://www.w3.org/TR/xml-names/#iri-use this is invalid:
> The empty string, though it is a legal URI reference, cannot be used as a namespace name. 

We want to use the xsd files to validate our xml files but because of `xmlns=""` validation fails:
```r
library("xml2")

doc <- read_xml("examples/Fusion/2.1/MS2 Scan Parameter/MS2.xml")
xsd <- read_xml("xsds/Calcium/2.1/MethodModifications.xsd")
xml_validate(doc, xsd)
# [1] FALSE
# attr(,"errors")
#  [1] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'ref': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
#  [2] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'type': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
#  [3] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'type': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
#  [4] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'type': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
#  [5] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'ref': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
#  [6] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'ref': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
#  [7] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'ref': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
#  [8] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'ref': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
#  [9] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'ref': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
# [10] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'ref': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
# [11] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'ref': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
# [12] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'ref': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
# [13] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'ref': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
# [14] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'ref': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
# [15] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'ref': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
# [16] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'ref': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
# [17] "Element '{http://www.w3.org/2001/XMLSchema}element', attribute 'ref': References from this schema to components in the namespace '' are not allowed, since not indicated by an import statement."
# [18] "Element 'MethodModifications': No matching global declaration available for the validation root."
```

This PR removes all `xmlns=""` from the xsd files. Subsequently the validation is working:

```r
library("xml2")

doc <- read_xml("examples/Fusion/2.1/MS2 Scan Parameter/MS2.xml")
xsd <- read_xml("xsds/Calcium/2.1/MethodModifications.xsd")
xml_validate(doc, xsd)
# [1] TRUE
# attr(,"errors")
# character(0)
```
It would be great if you could fix this (or accept this PR).

Best wishes,

Sebastian