### PR TITLE
Replace XCOPY by Copy task

### DIFF
--- a/xmlmethodchanger/XmlMethodChanger.lib/XmlMethodChanger.lib.csproj
+++ b/xmlmethodchanger/XmlMethodChanger.lib/XmlMethodChanger.lib.csproj
@@ -62,14 +62,14 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>XCOPY "$(SolutionDir)\..\xsds" "$(TargetDir)XSDs\" /S /Y</PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
-  </Target>
+  </Target> -->
   <Target Name="AfterBuild">
+    <ItemGroup>
+        <XsdFiles Include="$(SolutionDir)\..\xsds\**\*.xsd"/>
+    </ItemGroup>
+    <Copy SourceFiles="@(XsdFiles)" DestinationFolder="$(TargetDir)XSDs\%(RecursiveDir)" />
   </Target>
-  -->
 </Project>


### PR DESCRIPTION
Dear Thermo developers,

I try to build `XmlMethodChanger` on Linux using `mono` (`xbuild`). Because the `XmlMethodChanger.lib.csproj` uses `XCOPY` it is not platform independent. I replace the `XCOPY` call by the `Copy` task.

To build `XmlMethodChanger` on Linux you could run the following commands (on Debian stretch):
```
sudo apt install mono-complete
cd meth-modifications.org/xmlmethodchanger
nuget install CommandLineParser -Version 1.9.71 -OutputDirectory packages/
xbuild /p:TargetFrameworkVersion="v4.5" XmlMethodChanger.sln 
```

Best wishes,

Sebastian